### PR TITLE
added the weekly task 6 solution

### DIFF
--- a/Study Group Submissions/Challenge-3-Responses/jothilal22.md
+++ b/Study Group Submissions/Challenge-3-Responses/jothilal22.md
@@ -10,7 +10,6 @@ Imagine you have a website, and you want it to be super reliable and handle lots
 
 * First, there's the "simple-webapp," which is like the heart of your website. It knows how to show your web pages and listens for requests on the internet at port 8080.
 
-
 * Think of 'nginx-proxy' as a traffic director for your website, just like a friendly hotel receptionist. It stands at the main entrance (port 80) and guides visitors to the 'simple-webapp' (port 8080), ensuring they find what they're looking for on your website smoothly.
 
 First we will create a configmap 

--- a/Study Group Submissions/Challenge-6-Responses/jothilal22.md
+++ b/Study Group Submissions/Challenge-6-Responses/jothilal22.md
@@ -1,0 +1,167 @@
+**Name**: Jothilal Sottallu
+
+**Email**: srjothilal2001@gmail.com
+
+
+### SOLUTION
+
+### TASK : Kubernetes Challenge: Ingress and Networking
+
+### SOLUTION DETAILS
+
+### 1. Create a wear-deployment:
+Name: wear-deployment
+Image: kodekloud/ecommerce:apparels
+Port: 8080
+Expose this deployment
+
+First, I created the wear deployment file and then services 
+#### YAML
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wear-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wear
+  template:
+    metadata:
+      labels:
+        app: wear
+    spec:
+      containers:
+      - name: wear-container
+        image: kodekloud/ecommerce:apparels
+        ports:
+        - containerPort: 8080 
+```
+* Command to apply the Deployment 
+```Kubectl apply -f wear-deployment.yaml```
+
+### SERVICES
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: wear-service
+spec:
+  selector:
+    app: wear
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+
+```
+* Command to apply the Services
+```Kubectl apply -f wear-services.yaml```
+
+
+### 2. Create a video-deployment:
+
+#### YAML
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: video-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: video
+  template:
+    metadata:
+      labels:
+        app: video
+    spec:
+      containers:
+      - name: video-container
+        image: kodekloud/ecommerce:apparels
+        ports:
+        - containerPort: 8080 
+```
+* Command to apply the Deployment 
+```Kubectl apply -f video-deployment.yaml```
+
+### SERVICES
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: video-service
+spec:
+  selector:
+    app: video
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+
+```
+* Command to apply the Services
+```Kubectl apply -f video-services.yaml```
+
+#### 3.Create an Ingress:
+Name: ecommerce-ingress
+Annotations: nginx.ingress.kubernetes.io/rewrite-target: /
+Host: cka.kodekloud.local
+Paths:
+/wear routes to service wear
+/video routes to service video
+
+```
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ecommerce-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: cka.kodekloud.local
+    http:
+      paths:
+      - path: /wear
+        pathType: Prefix
+        backend:
+          service:
+            name: wear-service
+            port:
+              number: 8080
+      - path: /video
+        pathType: Prefix
+        backend:
+          service:
+            name: video-service
+            port:
+              number: 8080
+
+```
+Apply the Ingress configuration using kubectl apply -f ecommerce-ingress.yaml
+
+### 4.Point Virtual Domain
+
+```
+To point the virtual domain cka.kodekloud.local to cluster, need to modify local machine's DNS settings. Add an entry in machine's /etc/hosts
+
+192.168.99.100 cka.kodekloud.local
+```
+
+### 5. Verify
+
+1. Testing from Local Machine:
+
+Open a web browser and access cka.kodekloud.local/wear and cka.kodekloud.local/video. The traffic should be routed to the respective services.
+
+2. Testing from Cluster Pods:
+
+To ensure that pods within the cluster can access cka.kodekloud.local, may need to ensure DNS resolution within the cluster. Kubernetes typically sets up DNS resolution automatically for pods.
+
+```
+kubectl exec -it wear-d6d98d -- curl http://cka.kodekloud.local/wear
+
+```


### PR DESCRIPTION
Task 6: Kubernetes Challenge: Ingress and Networking

Challenge faced : Need to cautious setting up an Ingress controller can be complex, and misconfigurations can lead to routing issues
Pointing the virtual domain cka.kodekloud.local to cluster is challenging.DNS propagation take time.

Learning and Solution:Learned about Ingress controllers like Nginx Ingress and how they facilitate external access to services within a Kubernetes cluster.Learn how to set up path-based routing, where different paths in the URL route to different services within the clusters etc..